### PR TITLE
`egraph/...` benches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 criterion = "0.5.1"
 egg = "0.9.5"
 log = "0.4.21"
+rand = "0.8.5"
 
 [[bench]]
 name = "prop_logic"
@@ -20,4 +21,8 @@ harness = false
 
 [[bench]]
 name = "calc_logic"
+harness = false
+
+[[bench]]
+name = "egraph"
 harness = false

--- a/benches/basic_maths.rs
+++ b/benches/basic_maths.rs
@@ -95,7 +95,7 @@ pub fn basic_maths_benchmark(c: &mut Criterion) {
     );
 
     c.bench_function(
-        "basic_maths/foo",
+        "basic_maths/simpl2",
         |b| b.iter(|| {
             let result =  simplify(black_box("(+ (+ (+ 0 (* (* 1 foo) 0)) (* a 0)) a)"));
             assert_eq!(result, "a");

--- a/benches/calc_logic.rs
+++ b/benches/calc_logic.rs
@@ -85,7 +85,7 @@ pub fn calc_logic_benchmark(c: &mut Criterion) {
     let demorgan: RecExpr<CalcLogic> = "(== (!! (|| p q)) (&& (!! p) (!! q)))".parse().unwrap();
     c.bench_function( "calc_logic/demorgan",
         |b| b.iter(|| {
-            let res = simplify(black_box(&demorgan), black_box(&rules), 10, 5000);
+            let res = simplify(black_box(&demorgan), black_box(&rules), 10);
             assert!(tru.eq(&res))
         })
     );
@@ -94,7 +94,7 @@ pub fn calc_logic_benchmark(c: &mut Criterion) {
         .parse().unwrap();
     c.bench_function( "calc_logic/freges_theorem",
         |b| b.iter(|| {
-            let res = simplify(black_box(&frege), black_box(&rules), 10, 5000);
+            let res = simplify(black_box(&frege), black_box(&rules), 10);
             assert!(tru.eq(&res))
         })
     );

--- a/benches/egraph.rs
+++ b/benches/egraph.rs
@@ -1,0 +1,71 @@
+// rand_letter() = Symbol(rand('a':'z'))
+// 
+// function nested_expr(level)
+//   if level > 0
+//     :(($(rand_letter()))($(rand_letter())) + $(rand_letter()) + $(rand(1:100)) * $(nested_expr(level - 1)))
+//   else
+//     rand_letter()
+//   end
+// end
+// 
+// SUITE["egraph"]["addexpr"] = @benchmarkable EGraph($(nested_expr(2000)))
+
+extern crate rand;
+use rand::Rng;
+use std::char;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use egg::{*};
+
+
+define_language! {
+    pub enum BasicMath {
+        Num(i32),
+        "+" = Add([Id; 2]),
+        "*" = Mul([Id; 2]),
+        "call" = Call([Id; 2]),
+        Symbol(Symbol),
+    }
+}
+
+// Generates a random lowercase letter
+fn rand_letter() -> char {
+    let mut rng = rand::thread_rng();
+    rng.gen_range(b'a'..=b'z') as char
+}
+
+// Recursively creates a nested expression based on a level
+fn nested_expr(level: u32) -> String {
+    if level > 0 {
+        format!("(+ (call {} {}) (+ {} (* {} {})))",
+            rand_letter(),
+            rand_letter(),
+            rand_letter(),
+            rand::thread_rng().gen_range(1..=100),
+            nested_expr(level - 1)
+        )
+    } else {
+        rand_letter().to_string()
+    }
+}
+
+pub fn egraph_benchmark(c: &mut Criterion) {
+
+    c.bench_function("egraph/constructor",
+        |b| b.iter(|| {
+            let r: Runner<BasicMath,()> = Runner::default();
+            r
+        })
+    );
+
+    let expr: RecExpr<BasicMath> = nested_expr(2000).parse().unwrap();
+    c.bench_function( "egraph/addexpr",
+        |b| b.iter(|| {
+            let runner: Runner<BasicMath,()> = Runner::default().with_expr(black_box(&expr));
+            runner
+        })
+    );
+}
+
+criterion_group!(benches, egraph_benchmark);
+criterion_main!(benches);
+

--- a/benches/prop_logic.rs
+++ b/benches/prop_logic.rs
@@ -90,7 +90,7 @@ pub fn propositional_logic_benchmark(c: &mut Criterion) {
         .parse().unwrap();
     c.bench_function( "prop_logic/prove1",
         |b| b.iter(|| {
-            let result = prove(black_box(&ex_logic), black_box(&rules), 3, 6, 5000);
+            let result = prove(black_box(&ex_logic), black_box(&rules), 2, 6, &tru);
             assert_eq!(result, tru)
         })
     );
@@ -100,7 +100,7 @@ pub fn propositional_logic_benchmark(c: &mut Criterion) {
         .parse().unwrap();
     c.bench_function( "prop_logic/demorgan",
         |b| b.iter(|| {
-            let result = prove(black_box(&demorgan), black_box(&rules), 1, 10, 5000);
+            let result = prove(black_box(&demorgan), black_box(&rules), 1, 10, &tru);
             assert_eq!(result, tru)
         })
     );
@@ -111,7 +111,7 @@ pub fn propositional_logic_benchmark(c: &mut Criterion) {
     c.bench_function(
         "prop_logic/freges_theorem",
         |b| b.iter(|| {
-            let result = prove(black_box(&frege), black_box(&rules), 1, 10, 5000);
+            let result = prove(black_box(&frege), black_box(&rules), 1, 10, &tru);
             assert_eq!(result, tru)
         })
     );

--- a/scripts/load_results.jl
+++ b/scripts/load_results.jl
@@ -10,13 +10,13 @@ function load_results(path::String)
 
     # read results
     benchpaths = map(d -> joinpath(path, d, "new", "estimates.json"), dirs)
-    crit_results = Dict(bench => JSON.parsefile(path) for (bench, path) in zip(dirs, benchpaths))
+    crit_results = OrderedDict(bench => JSON.parsefile(path) for (bench, path) in zip(dirs, benchpaths))
 
     z75 = 1.15
     z95 = 1.96
 
     # output point estimates
-    Dict(
+    OrderedDict(
         bench => Dict(
             "median"=> d["median"]["point_estimate"],
             "mean"  => d["mean"]["point_estimate"],
@@ -29,13 +29,16 @@ function load_results(path::String)
 end
 
 
+MT_BRANCH = "nh/simpl2"
+
 air = AirspeedVelocity.load_results(
-    "Metatheory", ["nh/benchmark"],
+    "Metatheory", [MT_BRANCH],
     input_dir="/Users/niklas/.julia/dev/Metatheory/results"
 )
+
 results = OrderedDict(
     "egg" => load_results(joinpath(".", "target", "criterion")),
-    "Metatheory" => air["nh/benchmark"],
+    "Metatheory" => air[MT_BRANCH],
 )
 
 new_res = OrderedDict(

--- a/scripts/load_results.jl
+++ b/scripts/load_results.jl
@@ -29,11 +29,14 @@ function load_results(path::String)
 end
 
 
-results = AirspeedVelocity.load_results(
+air = AirspeedVelocity.load_results(
     "Metatheory", ["nh/benchmark"],
     input_dir="/Users/niklas/.julia/dev/Metatheory/results"
 )
-results["egg"] = load_results(joinpath(".", "target", "criterion"))
+results = OrderedDict(
+    "egg" => load_results(joinpath(".", "target", "criterion")),
+    "Metatheory" => air["nh/benchmark"],
+)
 
 new_res = OrderedDict(
     rev => OrderedDict(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,18 @@
-use egg::{*};
-
+use egg::*;
 
 pub fn simplify<L: Language>(
     expr: &RecExpr<L>,
     rules: &Vec<Rewrite<L, ()>>,
     timeout: usize,
-    eclasslimit: usize,
 ) -> RecExpr<L> {
     // run rules
-    let runner = saturate(&expr, rules, timeout, eclasslimit);
+    let scheduler = BackoffScheduler::default();
+    let runner = Runner::default()
+        .with_iter_limit(timeout)
+        .with_node_limit(15000)
+        .with_expr(&expr)
+        .with_scheduler(scheduler)
+        .run(rules);
 
     // extract shortest expression
     let extractor = Extractor::new(&runner.egraph, AstSize);
@@ -16,43 +20,38 @@ pub fn simplify<L: Language>(
     best
 }
 
-
-pub fn saturate<L: Language>(
-    expr: &RecExpr<L>,
-    rules: &Vec<Rewrite<L, ()>>,
-    timeout: usize,
-    eclasslimit: usize,
-) -> Runner<L,()> {
-    let scheduler = BackoffScheduler::default()
-        .with_initial_match_limit(6000)
-        .with_ban_length(5);
-    let runner = Runner::default()
-        .with_iter_limit(timeout)
-        .with_node_limit(eclasslimit)
-        .with_expr(&expr)
-        .with_scheduler(scheduler)
-        .run(rules);
-    runner
-}
-
-
 pub fn prove<L: Language>(
     expr: &RecExpr<L>,
     rules: &Vec<Rewrite<L, ()>>,
     steps: usize,
     timeout: usize,
-    eclasslimit: usize,
+    tru: &RecExpr<L>,
 ) -> RecExpr<L> {
-
-    let out: RecExpr<L> = (0..steps).fold(
-        expr.clone(),
-        |expr, _| {
-            let runner = saturate(&expr, &rules, timeout, eclasslimit);
-            let root = runner.roots[0];
-            let extractor = Extractor::new(&runner.egraph, AstSize);
-            let (_, best) = extractor.find_best(root);
-            best
-        }
-    );
+    let out: RecExpr<L> = (0..steps).fold(expr.clone(), |expr, _| {
+        let scheduler = BackoffScheduler::default()
+            .with_initial_match_limit(6000)
+            .with_ban_length(5);
+        let runner = Runner::default()
+            .with_iter_limit(timeout)
+            .with_node_limit(15000)
+            .with_expr(&expr)
+            .with_expr(&tru)
+            .with_scheduler(scheduler)
+            .with_hook(|runner| {
+                let istru =
+                    runner.egraph.find(runner.roots[0]) == runner.egraph.find(runner.roots[1]);
+                // println!("Is true??? {}", istru);
+                if istru {
+                    Err("PROVED".to_string())
+                } else {
+                    Ok(())
+                }
+            })
+            .run(rules);
+        let root = runner.roots[0];
+        let extractor = Extractor::new(&runner.egraph, AstSize);
+        let (_, best) = extractor.find_best(root);
+        best
+    });
     out
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use egg::{*, rewrite as rw};
 use egg_benchmark::{*};
+use std::time::Instant;
 
 define_language! {
     pub enum PropositionalLogic {
@@ -83,15 +84,32 @@ pub fn main() {
     let rules = propositional_logic_rules();
     let tru: RecExpr<PropositionalLogic> = "true".parse().unwrap();
 
+    // ===========================================
+
+    let apply_time: std::time::Instant = Instant::now();
+    
     // demorgan
     let ex_demorgan: RecExpr<PropositionalLogic> = "(== (!! (|| p q)) (&& (!! p) (!! q)))"
         .parse().unwrap();
-    println!("demorgan: {}", simplify(&ex_demorgan, &rules, 10, 5000).eq(&tru));
+    println!("demorgan: {}", prove(&ex_demorgan, &rules, 1, 10, &tru));
+
+    println!("simplification time {}", apply_time.elapsed().as_secs_f64());
+
+    // ===========================================
+
+    let apply_time: std::time::Instant = Instant::now();
 
     // frege
     let ex_frege: RecExpr<PropositionalLogic> = "(=> (=> p (=> q r)) (=> (=> p q) (=> p r)))"
         .parse().unwrap();
-    println!("frege:    {}", simplify(&ex_frege, &rules, 10, 5000));
+    println!("frege:    {}", prove(&ex_frege, &rules, 1, 10, &tru));
+
+    println!("simplification time {}", apply_time.elapsed().as_secs_f64());
+
+
+    // ===========================================
+
+    let apply_time: std::time::Instant = Instant::now();
 
     // let ex_logic = "(=> (&& (&& (=> p q) (=> r s)) (|| p r)) (|| q s))";
     let s = "(|| (!! (&& (|| (!! p) q) (&& (|| (!! r) s) (|| p r)))) (|| q s))";
@@ -99,7 +117,9 @@ pub fn main() {
     // let ex_logic = "(== p p)";
     
     let ex_logic: RecExpr<PropositionalLogic> = s.parse().unwrap();
-    let expr = prove(&ex_logic, &rules, 2, 6, 5000);
+    let expr = prove(&ex_logic, &rules, 2, 6, &tru);
     println!("logic:    {}", tru.eq(&expr));
+
+    println!("simplification time {}", apply_time.elapsed().as_secs_f64());
 }
 


### PR DESCRIPTION
Current benchmarks compared to Metatheory.jl (with updated prove/simplify, and updated parameters)

|                                 | egg                 | Metatheory          | egg/Metatheory |
|:--------------------------------|:-------------------:|:-------------------:|:--------------:|
| basic_maths_simpl1              | 25.8 ± 0.073 ms     | 8.25 ± 0.19 ms      | 3.13           |
| basic_maths_simpl2              | 0.0374 ± 6.8e-05 s  | 17.1 ± 1.5 ms       | 2.18           |
| calc_logic_demorgan             | 8.29 ± 0.0049 ms    | 0.169 ± 0.0031 ms   | 49             |
| calc_logic_freges_theorem       | 2.76 ± 0.0021 ms    |                     |                |
| egraph_addexpr                  | 0.749 ± 0.0026 ms   | 5.57 ± 0.31 ms      | 0.135          |
| egraph_constructor              | 0.0563 ± 2.7e-05 μs | 0.5 ± 0.12 μs       | 0.113          |
| prop_logic_demorgan             | 29.6 ± 0.025 μs     | 0.208 ± 0.0032 ms   | 0.142          |
| prop_logic_freges_theorem       | 1.07 ± 0.0013 ms    | 2.55 ± 0.06 ms      | 0.42           |
| prop_logic_prove1               | 18 ± 0.016 ms       | 0.0609 ± 0.0027 s   | 0.296          |
| while_superinterpreter_while_10 |                     | 25.1 ± 1.3 ms       |                |
| prop_logic_rewrite              |                     | 0.0741 ± 0.00054 ms |                |
| time_to_load                    |                     | 0.0412 ± 0.00098 s  |                |

