### PR TITLE
Test n_matches

### DIFF
--- a/tests/matches.rs
+++ b/tests/matches.rs
@@ -1,0 +1,26 @@
+use egg::{*};
+
+#[test]
+fn two_matches() {
+    let zero: SymbolLang = SymbolLang::leaf("0");
+    let one: SymbolLang = SymbolLang::leaf("1");
+    let foo: SymbolLang = SymbolLang::leaf("foo");
+    let onefoo: RecExpr<SymbolLang> = "(* 1 foo)".parse().unwrap();
+    let fooone: RecExpr<SymbolLang> = "(* foo 1)".parse().unwrap();
+
+    let mut egraph = EGraph::<SymbolLang, ()>::default();
+    egraph.add(zero);
+    egraph.add(one);
+    let foo_id: Id = egraph.add(foo);
+    let onefoo_id: Id = egraph.add_expr(&onefoo);
+    let fooone_id: Id = egraph.add_expr(&fooone);
+
+    egraph.union(foo_id, onefoo_id);
+    egraph.union(foo_id, fooone_id);
+    egraph.rebuild();
+
+    let rule: Rewrite<SymbolLang,()> = rewrite!("assoc"; "(* (* ?a ?b) ?c)" => "(* ?a (* ?b ?c))");
+    
+    assert_eq!(2, rule.searcher.n_matches(&egraph));
+// println!("{:?}", rule.search(&egraph));
+}


### PR DESCRIPTION
Verify that the julia code below
```julia
using Metatheory

g = EGraph(0)
one_id = addexpr!(g, 1)
foo_id = addexpr!(g, :foo)
onefoo_id = addexpr!(g, :(1 * foo))
fooone_id = addexpr!(g, :(foo * 1))

union!(g, foo_id, onefoo_id)
union!(g, foo_id, fooone_id)

r = @rule (~a * ~b) * ~c --> ~a * (~b * ~c)

r.ematcher!(g, 0, foo_id, r.ematcher_stack)
Metatheory.buffer_readable(g, 0)

3 E-Classes: [3, 2, 2] Nodes: [1, 1, 1]
3 E-Classes: [2, 3, 2] Nodes: [1, 1, 1]
```
produces the same matches in egg:
```
// tests/matches.rs outputs
[SearchMatches { eclass: 2, substs: [{?c: 1, ?a: 1, ?b: 2}, {?c: 1, ?a: 2, ?b: 1}], ...]
```
which it does!